### PR TITLE
Queue.Item.id is a long, not an int

### DIFF
--- a/queue.go
+++ b/queue.go
@@ -8,7 +8,7 @@ type Item struct {
 	Actions                    []Action `json:"actions"`
 	Blocked                    bool     `json:"blocked"`
 	Buildable                  bool     `json:"buildable"`
-	Id                         int      `json:"id"`
+	Id                         int64    `json:"id"`
 	InQueueSince               int64    `json:"inQueueSince"`
 	Params                     string   `json:"params"`
 	Stuck                      bool     `json:"stuck"`


### PR DESCRIPTION
Since https://github.com/jenkinsci/jenkins/pull/1566 in Jenkins 1.601, you need a 64-bit field here. I am not a Go dev so I am just guessing at this.

@reviewbybees